### PR TITLE
Flush stdout after each packet.

### DIFF
--- a/tls-hello-dump.c
+++ b/tls-hello-dump.c
@@ -511,6 +511,9 @@ int main(int argc, char **argv)
 	bpf_u_int32 mask;			/* subnet mask */
 	bpf_u_int32 net;			/* ip */
 
+	/* Make sure pipe sees new packets unbuffered. */
+	 setvbuf(stdout, (char *)NULL, _IOLBF, 0);
+
 	print_app_banner();
 
 	/* check for capture device name on command-line */


### PR DESCRIPTION
For systems with larger stdout buffer it can take quite some time
for the output to show up at the end of the pipe. Since lines
are constructed with multiple printf() it is best to keep buffer
and flush at end of each packet.

Noticed this problem on FreeBSD

Also write out the unknoin ip_p field value.
