### PR TITLE
README: Warn about default promisc mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ connection. This will bias your statistics towards clients with bad
 connectivity, and against long-living connections. *This is not a replacement
 for dumping the SSL/TLS ciphers from all open connections to your server.*
 
+If you specify a network device, it will enter PROMISC mode. Use only
+if you are authorized to sniff the network.
+
 ## Compilation
 
 To compile, simply run `make`. Have a look at the Makefile to tune the output


### PR DESCRIPTION
I would make it actually configurable (default off). If you do not want to introduce getop, one option would be to test if the devicename ends in \* and only then turn promisc on (or similiar?).
