### PR TITLE
handshake header too short: display remaining payload bytes

### DIFF
--- a/tls-hello-dump.c
+++ b/tls-hello-dump.c
@@ -434,7 +434,7 @@ got_packet(u_char *args, const struct pcap_pkthdr *header, const u_char *packet)
 		return;
 	}
 	if (size_payload < OFFSET_CIPHER_LIST + 3) { // at least one cipher + compression
-		printf("TLS handshake header too short: %u bytes\n", size_tcp);
+		printf("TLS handshake header too short: %d bytes\n", size_payload);
 		return;
 	}
 


### PR DESCRIPTION
Display the (possible negative) remaining payload size.

This really should check for underflows/overflows, but at least fix the c&p error.
